### PR TITLE
Added leading slash to server variables, which prevents Wordpress from generating incorrect links

### DIFF
--- a/apache2dummy
+++ b/apache2dummy
@@ -114,12 +114,10 @@ if [ ! -d /var/www/html/wordpress/wp-content/themes/suffusion ]; then
 
     #apt-get update
 
-    #  fix issue with wp-admin links stripping context
-    # TODO uncomment below
     echo "\$_SERVER['HTTP_HOST'] = \$_SERVER['HTTP_X_FORWARDED_HOST'];" >> wp-config.php
-    echo "\$_SERVER['REQUEST_URI'] = 'wordpress/$username' . \$_SERVER['REQUEST_URI']; " >> wp-config.php
-    echo "\$_SERVER['SCRIPT_NAME'] = 'wordpress/$username' . \$_SERVER['SCRIPT_NAME']; " >> wp-config.php
-    echo "\$_SERVER['PHP_SELF'] = 'wordpress/$username' . \$_SERVER['PHP_SELF']; " >> wp-config.php
+    echo "\$_SERVER['REQUEST_URI'] = '/wordpress/$username' . \$_SERVER['REQUEST_URI']; " >> wp-config.php
+    echo "\$_SERVER['SCRIPT_NAME'] = '/wordpress/$username' . \$_SERVER['SCRIPT_NAME']; " >> wp-config.php
+    echo "\$_SERVER['PHP_SELF'] = '/wordpress/$username' . \$_SERVER['PHP_SELF']; " >> wp-config.php
     echo "\$_SERVER['REMOTE_ADDR'] = \$_SERVER['HTTP_X_FORWARDED_FOR']; " >> wp-config.php
     echo "Updated wp-config.php"
     tail wp-config.php


### PR DESCRIPTION
This should address issue API017-31. Links in the admin interface which either:

* had missing slashes (`jupyter.edina.ac.ukwordpress/sdavies4`...)
* had repeated segments(`wordpress/sdavies4/wp-admin/wordpress/sdavies4/wp-admin`)

This appears to be because they concatenate some config variables together to make the path, and we were setting those config variables in the entrypoint script. Putting a leading slash on the variables seems to fix things, and also the 500 infinite redirection error on the map page, although I'm not too sure why it fixes the last one exactly.